### PR TITLE
tests: use sys.executable instead of hardcoded python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ gitfame
 
 |PyPI-Status| |PyPI-Versions|
 
-|Build-Status| |Coverage-Status| |Branch-Coverage-Status|
+|Build-Status| |Coverage-Status| |Branch-Coverage-Status| |Codacy-Grade|
 
 |LICENCE|
 
@@ -179,3 +179,5 @@ Authors
    :target: https://pypi.python.org/pypi/git-fame
 .. |LICENCE| image:: https://img.shields.io/pypi/l/git-fame.svg
    :target: https://mozilla.org/MPL/2.0/
+.. |Codacy-Grade| image:: https://api.codacy.com/project/badge/Grade/bde789ee0e57491eb2bb8609bd4190c3
+   :target: https://www.codacy.com/app/casper-dcl/git-fame

--- a/gitfame/tests/test_gitfame.py
+++ b/gitfame/tests/test_gitfame.py
@@ -52,7 +52,7 @@ def test_main():
   from copy import deepcopy
   from os.path import dirname as dn
 
-  res = subprocess.Popen(('python', '-c', "import gitfame; import sys;" +
+  res = subprocess.Popen((sys.executable, '-c', "import gitfame; import sys;" +
                           ' sys.argv = ["", "--silent-progress", "' +
                           dn(dn(dn(__file__))) +
                           '"]; gitfame.main()'),

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ except ImportError:
   from distutils.core import setup
 from gitfame import __licence__, __author__, __version__
 import io
+import sys
 try:
-  import sys
   if '--cython' in sys.argv:
     sys.argv.remove('--cython')
     from Cython.Build import cythonize


### PR DESCRIPTION
python != python3 in many cases.

Closes: https://github.com/casperdcl/git-fame/issues/5
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>