### PR TITLE
Add missing tqdm requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     platforms=['any'],
     packages=['gitfame'],
     provides=['gitfame'],
-    install_requires=['docopt'],
+    install_requires=['docopt', 'tqdm'],
     entry_points={'console_scripts': ['git-fame=gitfame:main'], },
     ext_modules=cythonize(["gitfame/_gitfame.py", "gitfame/_utils.py"],
                           nthreads=2),


### PR DESCRIPTION
This PR adds tqdm to the requirements so the user doesn't run into ```warning | module tqdm not found``` while using the package.