### PR TITLE
next release v1.11.0

### DIFF
--- a/.meta/.git-fame.1.md
+++ b/.meta/.git-fame.1.md
@@ -31,4 +31,6 @@ git fame --incl '\.[cht][puh]{0,2}$' -twMC
 # OPTIONS
 
 \<gitdir>
-: [default: ./]
+: Git directory [default: ./].
+May be specified multiple times to aggregate across
+multiple repositories.

--- a/.meta/.git-fame.1.md
+++ b/.meta/.git-fame.1.md
@@ -8,7 +8,7 @@ git-fame - Pretty-print `git` repository collaborators sorted by contributions.
 
 # SYNOPSIS
 
-gitfame [\--help | *options*] [<*gitdir*>]
+gitfame [\--help | *options*] [<*gitdir*>...]
 
 # DESCRIPTION
 

--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,12 @@ testtimer:
 	nosetests gitfame --with-timer -d -v
 
 gitfame/git-fame.1: .meta/.git-fame.1.md gitfame/_gitfame.py
-	python -m gitfame --help | tail -n+11 | head -n-2 |\
+	python -c 'import gitfame; print(gitfame._gitfame.__doc__.rstrip())' |\
+    grep -A999 '^Options:$$' | tail -n+2 |\
     sed -r -e 's/\\/\\\\/g' \
-      -e 's/^  (--\S+) (\S+)\s*(.*)$$/\n\\\1=*\2*\n: \3/' \
-      -e 's/^  (-\S+, )(-\S+)\s*/\n\\\1\\\2\n: /' |\
+      -e 's/^  (--\S+=)<(\S+)>\s+(.*)$$/\n\\\1*\2*\n: \3/' \
+      -e 's/^  (-., )(-\S+)\s*/\n\\\1\\\2\n: /' \
+      -e 's/^  (--\S+)\s+/\n\\\1\n: /' |\
     cat "$<" - |\
     pandoc -o "$@" -s -t man
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Pretty-print ``git`` repository collaborators sorted by contributions.
 .. code:: sh
 
     ~$ git fame --cost hour,month
-    Blame: 100%|██████████| 74/74 [00:00<00:00, 96.51file/s] 
+    Blame: 100%|██████████| 74/74 [00:00<00:00, 96.51file/s]
     Total commits: 1173
     Total ctimes: 1055
     Total files: 180
@@ -160,10 +160,12 @@ Documentation
 .. code::
 
     Usage:
-      gitfame [--help | options] [<gitdir>]
+      gitfame [--help | options] [<gitdir>...]
 
     Arguments:
       <gitdir>       Git directory [default: ./].
+                     May be specified multiple times to aggregate across
+                     multiple repositories.
 
     Options:
       -h, --help     Print this help and exit.
@@ -186,11 +188,11 @@ Documentation
       -s, --silent-progress    Suppress `tqdm` [default: False].
       --warn-binary   Don't silently skip files which appear to be binary data
                       [default: False].
+      -e, --show-email  Show author email instead of name [default: False].
       -t, --bytype             Show stats per file extension [default: False].
       -w, --ignore-whitespace  Ignore whitespace when comparing the parent's
                                version and the child's to find where the lines
                                came from [default: False].
-      -e, --show-email      Show author email instead of name [default: False].
       -M  Detect intra-file line moves and copies [default: False].
       -C  Detect inter-file line moves and copies [default: False].
       --format=<format>        Table format

--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -47,11 +47,11 @@ import logging
 import os
 from os import path
 import re
-from six import string_types
 import subprocess
 
 from ._utils import TERM_WIDTH, int_cast_or_len, fext, _str, \
-    check_output, tqdm, TqdmStream, print_unicode, Str, merge_stats
+    check_output, tqdm, TqdmStream, print_unicode, Str, string_types, \
+    merge_stats
 from ._version import __version__  # NOQA
 
 __author__ = "Casper da Costa-Luis <casper@caspersci.uk.to>"

--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -58,7 +58,7 @@ from ._utils import TERM_WIDTH, int_cast_or_len, fext, _str, \
 from ._version import __version__  # NOQA
 
 __author__ = "Casper da Costa-Luis <casper@caspersci.uk.to>"
-__date__ = "2016-2018"
+__date__ = "2016-2020"
 __licence__ = "[MPLv2.0](https://mozilla.org/MPL/2.0/)"
 __all__ = ["main"]
 __copyright__ = ' '.join(("Copyright (c)", __date__, __author__, __licence__))

--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -4,6 +4,8 @@ r"""Usage:
 
 Arguments:
   <gitdir>       Git directory [default: ./].
+                 May be specified multiple times to aggregate across
+                 multiple repositories.
 
 Options:
   -h, --help     Print this help and exit.

--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -43,9 +43,10 @@ Options:
 from __future__ import print_function
 from __future__ import division
 # from __future__ import absolute_import
-import subprocess
-import re
 import logging
+import os
+import re
+import subprocess
 
 from ._utils import TERM_WIDTH, int_cast_or_len, fext, _str, \
     check_output, tqdm, TqdmStream, print_unicode, Str
@@ -57,7 +58,7 @@ __licence__ = "[MPLv2.0](https://mozilla.org/MPL/2.0/)"
 __all__ = ["main"]
 __copyright__ = ' '.join(("Copyright (c)", __date__, __author__, __licence__))
 __license__ = __licence__  # weird foreign language
-
+log = logging.getLogger(__name__)
 
 RE_AUTHS = re.compile(
     r'^\w+ \d+ \d+ (\d+)\nauthor (.+?)$.*?\ncommitter-time (\d+)',
@@ -88,7 +89,6 @@ def tabulate(
   backends  : [default: md]|yaml|json|csv|tsv|tabulate|
     `in tabulate.tabulate_formats`
   """
-  log = logging.getLogger(__name__)
   COL_NAMES = ['Author', 'loc', 'coms', 'fils', ' distribution']
   it_as = getattr(auth_stats, 'iteritems', auth_stats.items)
   # get ready
@@ -323,7 +323,6 @@ def main(args=None):
       level=getattr(logging, args.log, logging.INFO),
       stream=TqdmStream,
       format="%(levelname)s:gitfame.%(funcName)s:%(lineno)d:%(message)s")
-  log = logging.getLogger(__name__)
 
   log.debug(args)
   if args.manpath is not None:

--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -120,9 +120,8 @@ def tabulate(
     stats_tot.setdefault('hours', '%.1f' % sum(i[1] for i in tab))
   # log.debug(auth_stats)
 
-  for i, j in [
-      ("commits", "coms"), ("files", "fils"), ("hours", "hrs"),
-      ("months", "mths")]:
+  for i, j in [("commits", "coms"), ("files", "fils"), ("hours", "hrs"),
+               ("months", "mths")]:
     sort = sort.replace(i, j)
   tab.sort(key=lambda i: i[COL_NAMES.index(sort)], reverse=True)
 
@@ -177,10 +176,11 @@ def tabulate(
     # return totals + tighten(tabber(...), max_width=TERM_WIDTH)
 
 
-def _get_auth_stats(gitdir, branch="HEAD", since=None,
-    include_files=None, exclude_files=None, silent_progress=False,
-    ignore_whitespace=False, M=False, C=False, warn_binary=False, bytype=False,
-    show_email=False, prefix_gitdir=False):
+def _get_auth_stats(
+        gitdir, branch="HEAD", since=None, include_files=None,
+        exclude_files=None, silent_progress=False, ignore_whitespace=False,
+        M=False, C=False, warn_binary=False, bytype=False, show_email=False,
+        prefix_gitdir=False):
   """Returns dict: {"<author>": {"loc": int, "files": {}, "commits": int,
                                  "ctimes": [int]}}"""
   since = ["--since", since] if since else []
@@ -307,8 +307,9 @@ def run(args):
 
   auth_stats = {}
   for gitdir in tqdm(gitdirs, desc="Repos", unit="repo",
-      disable=args.silent_progress or len(gitdirs) <= 1):
-    res = _get_auth_stats(gitdir, branch=args.branch, since=args.since,
+                     disable=args.silent_progress or len(gitdirs) <= 1):
+    res = _get_auth_stats(
+        gitdir, branch=args.branch, since=args.since,
         include_files=include_files, exclude_files=exclude_files,
         silent_progress=args.silent_progress,
         ignore_whitespace=args.ignore_whitespace, M=args.M, C=args.C,

--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -204,7 +204,7 @@ def _get_auth_stats(
   auth_stats = {}
   for fname in tqdm(file_list, desc=gitdir if prefix_gitdir else "Blame",
                     disable=silent_progress, unit="file"):
-    git_blame_cmd = git_cmd + ["blame", "--porcelain", branch, fname] + \
+    git_blame_cmd = git_cmd + ["blame", "--line-porcelain", branch, fname] + \
         since
     if prefix_gitdir:
       fname = path.join(gitdir, fname)

--- a/gitfame/_utils.py
+++ b/gitfame/_utils.py
@@ -235,7 +235,7 @@ def print_unicode(msg, end='\n', err='?'):
       print(c, end='')
     except UnicodeEncodeError:
       print(err, end='')
-  print ('', end=end)
+  print('', end=end)
 
 
 def Str(i):

--- a/gitfame/_utils.py
+++ b/gitfame/_utils.py
@@ -9,11 +9,13 @@ try:
   _str = unicode
   _range = xrange
   from StringIO import StringIO
+  string_types = (basestring,)
 except NameError:
   # python3
   _str = str
   _range = range
   from io import StringIO
+  string_types = (str,)
 
 try:
   from tqdm import tqdm

--- a/gitfame/_utils.py
+++ b/gitfame/_utils.py
@@ -244,3 +244,17 @@ def Str(i):
     return '%g' % i
   except TypeError:
     return _str(i)
+
+
+def merge_stats(left, right):
+  """Add `right`'s values to `left` (modifies `left` in-place)"""
+  for k, val in getattr(right, 'iteritems', right.items)():
+    if isinstance(val, int):
+      left[k] += val
+    elif hasattr(val, 'extend'):
+      left[k].extend(val)
+    elif hasattr(val, 'update'):
+      left[k].update(val)
+    else:
+      raise TypeError(val)
+  return left

--- a/gitfame/_utils.py
+++ b/gitfame/_utils.py
@@ -39,7 +39,7 @@ except ImportError:
       sys.stderr.write(msg + end)
 
 __author__ = "Casper da Costa-Luis <casper@caspersci.uk.to>"
-__date__ = "2016-2018"
+__date__ = "2016-2020"
 __licence__ = "[MPLv2.0](https://mozilla.org/MPL/2.0/)"
 __all__ = ["TERM_WIDTH", "int_cast_or_len", "Max", "fext", "_str", "tqdm",
            "tighten", "check_output", "print_unicode", "StringIO", "Str"]
@@ -133,7 +133,6 @@ def _environ_cols_windows(fp):  # pragma: no cover
 def _environ_cols_tput(*args):  # pragma: no cover
   """cygwin xterm (windows)"""
   try:
-    import subprocess
     import shlex
     cols = int(subprocess.check_call(shlex.split('tput cols')))
     # rows = int(subprocess.check_call(shlex.split('tput lines')))

--- a/gitfame/_utils.py
+++ b/gitfame/_utils.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import sys
 import subprocess
 import logging
+log = logging.getLogger(__name__)  # NOQA
 
 try:
   # python2
@@ -19,7 +20,6 @@ try:
 except ImportError:
   class tqdm(object):
     def __init__(self, iterable=None, **kwargs):
-      log = logging.getLogger(__name__)
       log.info('install `tqdm` (https://github.com/tqdm/tqdm)'
                ' for a realtime progressbar')
       self.iterable = iterable
@@ -57,7 +57,6 @@ class TqdmStream(object):
 
 
 def check_output(*a, **k):
-  log = logging.getLogger(__name__)
   log.debug(' '.join(a[0][3:]))
   k.setdefault('stdout', subprocess.PIPE)
   return subprocess.Popen(*a, **k).communicate()[0].decode('utf-8')

--- a/gitfame/git-fame.1
+++ b/gitfame/git-fame.1
@@ -33,12 +33,24 @@ git\ fame\ \-\-incl\ \[aq]\\.[cht][puh]{0,2}$\[aq]\ \-twMC
 .SH OPTIONS
 .TP
 .B <gitdir>
-[default: ./]
+Git directory [default: ./].
+May be specified multiple times to aggregate across multiple
+repositories.
 .RS
 .RE
 .TP
 .B \-h, \-\-help
-show this help message and exit
+Print this help and exit.
+.RS
+.RE
+.TP
+.B \-v, \-\-version
+Print module version and exit.
+.RS
+.RE
+.TP
+.B \-\-branch=\f[I]b\f[]
+Branch or tag [default: HEAD] up to which to check.
 .RS
 .RE
 .TP
@@ -47,33 +59,10 @@ show this help message and exit
 .RS
 .RE
 .TP
-.B \-t, \-\-bytype
-Show stats per file extension [default: False].
-.RS
-.RE
-.TP
-.B \-\-log=\f[I]lvl\f[]
-FATAL|CRITICAL|ERROR|WARN(ING)|[default: INFO]|DEBUG|NOTSET.
-.RS
-.RE
-.TP
-.B \-\-cost=\f[I]method\f[]
-Include time cost in person\-months (COCOMO) or person\- hours (based on
-commit times).
-Methods: month(s)|cocomo|hour(s)|commit(s).
-May be multiple comma\-separated values.
-.RS
-.RE
-.TP
-.B \-w, \-\-ignore\-whitespace
-.IP
-.nf
-\f[C]
-\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ Ignore\ whitespace\ when\ comparing\ the\ parent\[aq]s\ version
-\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ and\ the\ child\[aq]s\ to\ find\ where\ the\ lines\ came\ from
-\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ [default:\ False].
-\f[]
-.fi
+.B \-\-excl=\f[I]f\f[]
+Excluded files (default: None).
+In no\-regex mode, may be a comma\-separated list.
+Escape (\\,) for a literal comma (may require \\\\, in shell).
 .RS
 .RE
 .TP
@@ -83,54 +72,17 @@ See \f[C]\-\-excl\f[] for format.
 .RS
 .RE
 .TP
-.B \-\-format=\f[I]format\f[]
-Table format [default: pipe]|md|markdown|yaml|yml|json|csv|tsv|tabulate.
-May require \f[C]git\-fame[<format>]\f[], e.g.
-\f[C]pip\ install\ git\-\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ fame[yaml]\f[].
-Any \f[C]tabulate.tabulate_formats\f[] is also accepted.
-.RS
-.RE
-.TP
-.B \-\-branch=\f[I]b\f[]
-Branch or tag [default: HEAD] up to which to check.
-.RS
-.RE
-.TP
-.B \-C, \-C
-Detect inter\-file line moves and copies [default: False].
-.RS
-.RE
-.TP
 .B \-\-since=\f[I]date\f[]
 Date from which to check.
 Can be absoulte (eg: 1970\-01\-31) or relative to now (eg: 3.weeks).
 .RS
 .RE
 .TP
-.B \-v, \-\-version
-show program\[aq]s version number and exit
-.RS
-.RE
-.TP
-.B \-s, \-\-silent\-progress
-.IP
-.nf
-\f[C]
-\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ Suppress\ `tqdm`\ [default:\ False].
-\f[]
-.fi
-.RS
-\-\-warn\-binary Don\[aq]t silently skip files which appear to be binary
-data [default: False].
-.RE
-.TP
-.B \-e, \-\-show\-email
-Show author email instead of name [default: False].
-.RS
-.RE
-.TP
-.B \-M, \-M
-Detect intra\-file line moves and copies [default: False].
+.B \-\-cost=\f[I]method\f[]
+Include time cost in person\-months (COCOMO) or person\-hours (based on
+commit times).
+Methods: month(s)|cocomo|hour(s)|commit(s).
+May be multiple comma\-separated values.
 .RS
 .RE
 .TP
@@ -141,15 +93,50 @@ NB: if regex is enabled \f[C],\f[] is equivalent to \f[C]|\f[].
 .RS
 .RE
 .TP
+.B \-s, \-\-silent\-progress
+Suppress \f[C]tqdm\f[] [default: False].
+.RS
+.RE
+.TP
+.B \-\-warn\-binary
+Don\[aq]t silently skip files which appear to be binary data [default:
+False].
+.RS
+.RE
+.TP
+.B \-e, \-\-show\-email
+Show author email instead of name [default: False].
+.RS
+.RE
+.TP
+.B \-t, \-\-bytype
+Show stats per file extension [default: False].
+.RS
+.RE
+.TP
+.B \-w, \-\-ignore\-whitespace
+Ignore whitespace when comparing the parent\[aq]s version and the
+child\[aq]s to find where the lines came from [default: False].
+\-M Detect intra\-file line moves and copies [default: False].
+\-C Detect inter\-file line moves and copies [default: False].
+.RS
+.RE
+.TP
+.B \-\-format=\f[I]format\f[]
+Table format [default: pipe]|md|markdown|yaml|yml|json|csv|tsv|tabulate.
+May require \f[C]git\-fame[<format>]\f[], e.g.
+\f[C]pip\ install\ git\-fame[yaml]\f[].
+Any \f[C]tabulate.tabulate_formats\f[] is also accepted.
+.RS
+.RE
+.TP
 .B \-\-manpath=\f[I]path\f[]
 Directory in which to install git\-fame man pages.
 .RS
 .RE
 .TP
-.B \-\-excl=\f[I]f\f[]
-Excluded files (default: None).
-In no\-regex mode, may be a comma\-separated list.
-Escape (\\,) for a literal comma (may require \\\\, in shell).
+.B \-\-log=\f[I]lvl\f[]
+FATAL|CRITICAL|ERROR|WARN(ING)|[default: INFO]|DEBUG|NOTSET.
 .RS
 .RE
 .SH AUTHORS

--- a/gitfame/git-fame.1
+++ b/gitfame/git-fame.1
@@ -8,7 +8,7 @@ git\-fame \- Pretty\-print \f[C]git\f[] repository collaborators sorted
 by contributions.
 .SH SYNOPSIS
 .PP
-gitfame [\-\-help | \f[I]options\f[]] [<\f[I]gitdir\f[]>]
+gitfame [\-\-help | \f[I]options\f[]] [<\f[I]gitdir\f[]>...]
 .SH DESCRIPTION
 .PP
 See <https://github.com/casperdcl/git-fame>.

--- a/gitfame/tests/tests_gitfame.py
+++ b/gitfame/tests/tests_gitfame.py
@@ -228,4 +228,7 @@ def test_main():
   assert path.exists(man)
   rmtree(tmp, True)
 
+  # test multiple gitdirs
+  main(['.', '.'])
+
   sys.argv, sys.stdout, sys.stderr = _SYS_AOE

--- a/gitfame/tests/tests_gitfame.py
+++ b/gitfame/tests/tests_gitfame.py
@@ -192,7 +192,6 @@ def test_main():
     res = ' '.join(sys.stdout.getvalue().strip().split()[:2])
     if res != "usage: gitfame":
       raise ValueError(sys.stdout.getvalue())
-      raise ValueError(res)
   else:
     raise ValueError("Expected --bad arg to fail")
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from ast import literal_eval
+from io import open as io_open
 import os
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 import sys
-from io import open as io_open
 
 try:
     if '--cython' in sys.argv:
@@ -25,8 +26,10 @@ __version__ = None
 src_dir = os.path.abspath(os.path.dirname(__file__))
 main_file = os.path.join(src_dir, 'gitfame', '_gitfame.py')
 for l in io_open(main_file, mode='r'):
-    if any(l.startswith(i) for i in ('__author__', '__licence__')):
-        exec(l)
+    if l.startswith('__author__'):
+        __author__ = literal_eval(l.split('=', 1)[1].strip())
+    elif l.startswith('__licence__'):
+        __licence__ = literal_eval(l.split('=', 1)[1].strip())
 version_file = os.path.join(src_dir, 'gitfame', '_version.py')
 with io_open(version_file, mode='r') as fd:
     exec(fd.read())

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ if sys.argv[1].lower().strip() == 'make':
 
 extras_require = dict(yaml=['pyyaml'], tabulate=[])
 extras_require['full'] = list(set(sum(extras_require.values(), ['tqdm'])))
-extras_require['dev'] = list(set(extras_require['full'] + ['py-make>=0.1.0', 'twine']))
+extras_require['dev'] = list(set(
+    extras_require['full'] + ['py-make>=0.1.0', 'twine']))
 
 README_rst = ''
 fndoc = os.path.join(src_dir, 'README.rst')
@@ -127,7 +128,7 @@ setup(
         'Topic :: Terminals',
         'Topic :: Utilities'
     ],
-    keywords='git blame git-blame git-log code-analysis cost loc' +
+    keywords='git blame git-blame git-log code-analysis cost loc'
              ' author commit shortlog ls-files',
     test_suite='nose.collector',
     tests_require=['nose', 'flake8', 'coverage'],


### PR DESCRIPTION
- support aggregating multiple repositories (#24)
- re-fix under-counting `loc` (#28, #15)
- update documentation

---

- `.mailmap` is respected per-repository to help with aggregating stats
- `--branch` (default: `HEAD`, i.e. current) is shared across all repos
  + will have to think about how to specify per-repo branches if there is enough demand for it
  + in the meantime, work-around is to checkout desired branches before running `git-fame`
- `argopt`/`docopt`/`argparse` don't seem to order options consistently, so now manpages are generated directly from the docstring
- fixes #24
- fixes #28
- enhances/re-fixes #15