### PR TITLE
Multiple fixes for bugs around --show-email and --since=<date>

### DIFF
--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -265,7 +265,16 @@ def _get_auth_stats(
     old = auth_stats
     auth_stats = {}
     for auth, stats in getattr(old, 'iteritems', old.items)():
-      auth_stats[auth2em[auth]] = stats
+      # Some users will change their name over time while keeping the same email address,
+      # such as capitalization or middle names shown.
+      # Handle this by merging together all stats for same email
+      i = auth_stats.setdefault(auth2em[auth], { "loc": 0, "files": set([]), "commits": 0, "ctimes": [] })
+      i["loc"] += stats["loc"]
+      i["files"].update(stats["files"])
+      i["commits"] += stats["commits"]
+      i["ctimes"] += stats["ctimes"]
+      # mutating the returned object sidesteps the need to perform another dict lookup
+      # auth_stats[auth2em[auth]] = i
     del old
 
   return auth_stats


### PR DESCRIPTION
Hello git-fame maintainers, 

I have a PR for you that resolves several bugs we ran into while using this tool. Please see the commit messages for descriptions of the changes.

Known bug resolved: #31 
New bug resolved: Crash to stack trace when using a selection range (e.g. --since=<date>) and --show-email
New bug resolved: Committers that ever used more than one name (as judged by string comparison) with the same email would only have the stats earned by one of those names, causing data loss.