### PR TITLE
Keeping the Fame alive (by removing the blame)...

### DIFF
--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -206,7 +206,7 @@ def _get_auth_stats(
   log.log(logging.NOTSET, "files:\n" + '\n'.join(file_list))
 
   auth_stats = {}
-  for fname in tqdm(file_list, desc=gitdir if prefix_gitdir else "fame",
+  for fname in tqdm(file_list, desc=gitdir if prefix_gitdir else "Processing",
                     disable=silent_progress, unit="file"):
     git_blame_cmd = git_cmd + ["blame", "--line-porcelain", branch, fname] + \
         since

--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -206,7 +206,7 @@ def _get_auth_stats(
   log.log(logging.NOTSET, "files:\n" + '\n'.join(file_list))
 
   auth_stats = {}
-  for fname in tqdm(file_list, desc=gitdir if prefix_gitdir else "Blame",
+  for fname in tqdm(file_list, desc=gitdir if prefix_gitdir else "fame",
                     disable=silent_progress, unit="file"):
     git_blame_cmd = git_cmd + ["blame", "--line-porcelain", branch, fname] + \
         since


### PR DESCRIPTION
I heard about this over on https://pythonbytes.fm/episodes/show/187/ready-to-find-out-if-you-re-git-famous and as I'm also a contributor to https://gist.github.com/amitchhajer/4461043 (to add what you have as ``--show-email``) I just had to say hi :-)

This one makes a tiny change - the repos I work with are often big enough that the tqdm takes fully 30 seconds to make it to 100%, and I noticed the "Blame" and thought it'd be nicer for it to be "fame" :-)
