### PR TITLE
Fix a UnicodeDecodeError

### DIFF
--- a/gitfame/_utils.py
+++ b/gitfame/_utils.py
@@ -69,7 +69,7 @@ class TqdmStream(object):
 def check_output(*a, **k):
   log.debug(' '.join(a[0][3:]))
   k.setdefault('stdout', subprocess.PIPE)
-  return subprocess.Popen(*a, **k).communicate()[0].decode('utf-8')
+  return subprocess.Popen(*a, **k).communicate()[0].decode('utf-8', errors='replace')
 
 
 def blank_col(rows, i, blanks):


### PR DESCRIPTION
While `git fame`-ing [OctoPrint/OctoPrint](https://github.com/OctoPrint/OctoPrint) I ran into a UnicodeDecodeError due to 
a non-utf8 author name somewhere in the history. 

```
(venv3) gina@nuc-linuxmint:~/devel/OctoPrint/OctoPrint$ git-fame .
Blame: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 781/781 [00:25<00:00, 30.72file/s]
Traceback (most recent call last):
  File "/home/gina/devel/OctoPrint/venv3/bin/git-fame", line 8, in <module>
    sys.exit(main())
  File "/home/gina/devel/OctoPrint/venv3/lib/python3.6/site-packages/gitfame/_gitfame.py", line 396, in main
    run(args)
  File "/home/gina/devel/OctoPrint/venv3/lib/python3.6/site-packages/gitfame/_gitfame.py", line 348, in run
    for res in mapper(statter, gitdirs):
  File "/home/gina/devel/OctoPrint/venv3/lib/python3.6/site-packages/gitfame/_gitfame.py", line 255, in _get_auth_stats
    git_cmd + ["shortlog", "-s", "-e", branch] + since)
  File "/home/gina/devel/OctoPrint/venv3/lib/python3.6/site-packages/gitfame/_utils.py", line 72, in check_output
    return subprocess.Popen(*a, **k).communicate()[0].decode('utf-8')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe4 in position 2923: invalid continuation byte
```

No idea how that got in there but it's too late to fix it now in the repo's history.

This patch works around this by setting `errors='replace'` on the `decode` in question. 
IMHO it's a better default behaviour here to replace errors with the UTF-8 placeholder 
character than to completely fail, but YMMV of course.

Awesome tool btw! Heard about it on the Python Bytes podcast, thank you for sharing!