### PR TITLE
Fix KeyError in merging loc by type from different repositories

### DIFF
--- a/gitfame/_utils.py
+++ b/gitfame/_utils.py
@@ -258,7 +258,7 @@ def merge_stats(left, right):
   """Add `right`'s values to `left` (modifies `left` in-place)"""
   for k, val in getattr(right, 'iteritems', right.items)():
     if isinstance(val, int):
-      left[k] += val
+      left[k] = left.get(k, 0) + val
     elif hasattr(val, 'extend'):
       left[k].extend(val)
     elif hasattr(val, 'update'):


### PR DESCRIPTION
First of all I wanted to thank you for your work! I found your project when searching for a tool to measure my overall contributions over several projects and it's perfect.

I tried with a couple of repos and it worked like a charm, then I added all of them (~15) and I encountered a KeyError:
```
Traceback (most recent call last):
  File "c:\users\paolo simone\appdata\local\programs\python\python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\users\paolo simone\appdata\local\programs\python\python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\Paolo Simone\AppData\Local\Programs\Python\Python37\Scripts\git-fame.exe\__main__.py", line 9, in <module>
  File "c:\users\paolo simone\appdata\local\programs\python\python37\lib\site-packages\gitfame\_gitfame.py", line 396, in main
    run(args)
  File "c:\users\paolo simone\appdata\local\programs\python\python37\lib\site-packages\gitfame\_gitfame.py", line 351, in run
    merge_stats(auth_stats[auth], stats)
  File "c:\users\paolo simone\appdata\local\programs\python\python37\lib\site-packages\gitfame\_utils.py", line 261, in merge_stats
    left[k] += val
KeyError: '.json'
```

I think the problem is that the repos contain files with different extensions and I specified the `-t` option, e.g.
```
git-fame -t python-project javascript-project
```

Since not all file extensions are in all repos could be that `auth_stats[auth][fext_key]` is not already present when merging stats across repos, e.g. `python-project` contains only `.py` files and `javascript-project` contains only `.js` files.

A quick but effective solution would be initializing the loc counter to 0 if the key is missing. Hope it could help!