### PR TITLE
next release v1.12.2

### DIFF
--- a/gitfame/_utils.py
+++ b/gitfame/_utils.py
@@ -18,33 +18,15 @@ except NameError:
   from io import StringIO
   string_types = (str,)
 
+from tqdm import tqdm
+from tqdm.utils import _screen_shape_wrapper
 try:
-  from tqdm import tqdm
-  try:
-    from threading import RLock
-  except ImportError:
-    pass
-  else:
-    tqdm.set_lock(RLock())
-    tqdm = partial(tqdm, lock_args=(False,))
+  from threading import RLock
 except ImportError:
-  class tqdm(object):
-    def __init__(self, iterable=None, **kwargs):
-      log.info('install `tqdm` (https://github.com/tqdm/tqdm)'
-               ' for a realtime progressbar')
-      self.iterable = iterable
-      self.n = 0
-
-    def __iter__(self):
-      for i in self.iterable:
-        self.n += 1
-        sys.stderr.write("%d/%d\r" % (self.n, len(self.iterable)))
-        sys.stderr.flush()
-        yield i
-
-    @classmethod
-    def write(cls, msg, end='\n'):
-      sys.stderr.write(msg + end)
+  pass
+else:
+  tqdm.set_lock(RLock())
+  tqdm = partial(tqdm, lock_args=(False,))
 
 __author__ = "Casper da Costa-Luis <casper@caspersci.uk.to>"
 __date__ = "2016-2020"
@@ -54,16 +36,16 @@ __all__ = ["TERM_WIDTH", "int_cast_or_len", "Max", "fext", "_str", "tqdm",
 __copyright__ = ' '.join(("Copyright (c)", __date__, __author__, __licence__))
 __license__ = __licence__  # weird foreign language
 
+TERM_WIDTH = _screen_shape_wrapper()(sys.stdout)[0]
+if not TERM_WIDTH:
+  # non interactive pipe
+  TERM_WIDTH = 256
+
 
 class TqdmStream(object):
   @classmethod
   def write(cls, msg):
     tqdm.write(msg, end='')
-
-  # is this required?
-  # @classmethod
-  # def flush(_):
-  #   pass
 
 
 def check_output(*a, **k):
@@ -112,95 +94,6 @@ def fext(fn):
   """File extension"""
   res = fn.split('.')
   return res[-1] if len(res) > 1 else ''
-
-
-def _environ_cols_windows(fp):  # pragma: no cover
-  try:
-    from ctypes import windll, create_string_buffer
-    import struct
-    from sys import stdin, stdout
-
-    io_handle = -12  # assume stderr
-    if fp == stdin:
-      io_handle = -10
-    elif fp == stdout:
-      io_handle = -11
-
-    h = windll.kernel32.GetStdHandle(io_handle)
-    csbi = create_string_buffer(22)
-    res = windll.kernel32.GetConsoleScreenBufferInfo(h, csbi)
-    if res:
-      (_bufx, _bufy, _curx, _cury, _wattr, left, _top, right, _bottom,
-       _maxx, _maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
-      # nlines = bottom - top + 1
-      return right - left  # +1
-  except:
-    pass
-  return None
-
-
-def _environ_cols_tput(*args):  # pragma: no cover
-  """cygwin xterm (windows)"""
-  try:
-    import shlex
-    cols = int(subprocess.check_call(shlex.split('tput cols')))
-    # rows = int(subprocess.check_call(shlex.split('tput lines')))
-    return cols
-  except:
-    pass
-  return None
-
-
-def _environ_cols_linux(fp):  # pragma: no cover
-
-  # import os
-  # if fp is None:
-  #   try:
-  #     fp = os.open(os.ctermid(), os.O_RDONLY)
-  #   except:
-  #     pass
-  try:
-    from termios import TIOCGWINSZ
-    from fcntl import ioctl
-    from array import array
-  except ImportError:
-    return None
-  else:
-    try:
-      return array('h', ioctl(fp, TIOCGWINSZ, '\0' * 8))[1]
-    except:
-      try:
-        from os.environ import get
-      except ImportError:
-        return None
-      else:
-        return int(get('COLUMNS', 1)) - 1
-
-
-def _environ_cols_wrapper():  # pragma: no cover
-  """
-  Return a function which gets width and height of console
-  (linux,osx,windows,cygwin).
-
-  Based on https://raw.githubusercontent.com/tqdm/tqdm/master/tqdm/_utils.py
-  """
-  import platform
-  current_os = platform.system()
-  _environ_cols = None
-  if current_os in ['Windows', 'cli']:
-    _environ_cols = _environ_cols_windows
-    if _environ_cols is None:
-      _environ_cols = _environ_cols_tput
-  if any(current_os.startswith(i) for i in
-         ['CYGWIN', 'MSYS', 'Linux', 'Darwin', 'SunOS', 'FreeBSD']):
-    _environ_cols = _environ_cols_linux
-  return _environ_cols
-
-
-TERM_WIDTH = _environ_cols_wrapper()(sys.stdout)
-if not TERM_WIDTH:
-  # non interactive pipe
-  TERM_WIDTH = 256
 
 
 def int_cast_or_len(i):

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if sys.argv[1].lower().strip() == 'make':
 
 extras_require = dict(yaml=['pyyaml'], tabulate=[])
 extras_require['full'] = list(set(sum(
-    extras_require.values(), ['tqdm>=4.42.0'])))
+    extras_require.values(), [])))
 extras_require['dev'] = list(set(
     extras_require['full'] + ['py-make>=0.1.0', 'twine']))
 
@@ -63,7 +63,7 @@ setup(
     platforms=['any'],
     packages=['gitfame'],
     provides=['gitfame'],
-    install_requires=['argopt>=0.3.5', 'tabulate'],
+    install_requires=['argopt>=0.3.5', 'tabulate', 'tqdm>=4.44.0'],
     extras_require=extras_require,
     entry_points={'console_scripts': ['git-fame=gitfame:main'], },
     package_data={'gitfame': ['LICENCE', 'git-fame.1']},


### PR DESCRIPTION
- update tab completion script
- add `tqdm>=4.44.0` dependency (#42)
  + v4.44.0 for screen width detection
  + v4.42.0 for concurrent processing of multiple repos
  + v4.38.0 for efficient locking
  + remove unneeded `ImportError("tqdm")` code

---

- fixes #42
  + No real point in having `tqdm` as a soft dependency any more. Making it a hard dependency also means there's no need to re-implement utility/helper functions.