### PR TITLE
Fixes quotes for alias registration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ This is probably not necessary on UNIX systems.
 
 .. code:: sh
 
-    git config --global alias.fame "!python -m gitfame"
+    git config --global alias.fame '!python -m gitfame'
 
 Tab completion
 ~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,14 @@ Latest Docker release
 Register alias with git
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+On Windows, run:
+
+.. code:: sh
+
+    git config --global alias.fame "!python -m gitfame"
+
 This is probably not necessary on UNIX systems.
+If ``git fame`` doesn't work after restarting the terminal on Linux & Mac OS, try (with single quotes):
 
 .. code:: sh
 


### PR DESCRIPTION
Fixes #55, as the way that I got the alias to register correctly on OSX is:
```
git config --global alias.fame '!python -m gitfame'
```

Please note that
a) I have only tested this on OSX
b) I have not tested if on OSX I even need to register that alias at all

Hope this is still useful.