### PR TITLE
Use hyphenized git-fame in help texts of standalone invocation

### DIFF
--- a/.meta/.git-fame.1.md
+++ b/.meta/.git-fame.1.md
@@ -8,7 +8,7 @@ git-fame - Pretty-print `git` repository collaborators sorted by contributions.
 
 # SYNOPSIS
 
-gitfame [\--help | *options*] [<*gitdir*>...]
+git-fame [\--help | *options*] [<*gitdir*>...]
 
 # DESCRIPTION
 

--- a/README.rst
+++ b/README.rst
@@ -175,7 +175,7 @@ Documentation
 .. code::
 
     Usage:
-      gitfame [--help | options] [<gitdir>...]
+      git-fame [--help | options] [<gitdir>...]
 
     Arguments:
       <gitdir>       Git directory [default: ./].

--- a/gitfame/git-fame.1
+++ b/gitfame/git-fame.1
@@ -8,7 +8,7 @@ git\-fame \- Pretty\-print \f[C]git\f[] repository collaborators sorted
 by contributions.
 .SH SYNOPSIS
 .PP
-gitfame [\-\-help | \f[I]options\f[]] [<\f[I]gitdir\f[]>...]
+git\-fame [\-\-help | \f[I]options\f[]] [<\f[I]gitdir\f[]>...]
 .SH DESCRIPTION
 .PP
 See <https://github.com/casperdcl/git-fame>.


### PR DESCRIPTION
I don't have a `gitfame` binary in my system after installing git-fame with pip.
This change adjusts the instructions to reflect that, recommending usage of `git-fame` instead of `gitfame`.﻿
