### PR TITLE
Remove dubious ownership error with docker image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ Latest Docker release
 
     docker pull casperdcl/git-fame
     docker run --rm casperdcl/git-fame --help
-    docker run --rm -v </local/path/to/repository>:/repo casperdcl/git-fame
+    docker run --rm -v </local/path/to/repository>:/repo --user "$(id --user)" casperdcl/git-fame
 
 Register alias with git
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ Latest Docker release
 
     docker pull casperdcl/git-fame
     docker run --rm casperdcl/git-fame --help
-    docker run --rm -v </local/path/to/repository>:/repo --user "$(id --user)" casperdcl/git-fame
+    docker run --rm -v "$(pwd):/repo" --user "$(id --user)" casperdcl/git-fame
 
 Register alias with git
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
When using docker, instruct the  (human) user to run the docker image with the current (unix) user.

Fixes the "fatal: detected dubious ownership in repository at '/repo'" error message.
Fixes #81 (I prefer changing the `docker run` command than modifying the docker image)

**Before:**
```bash
[nathanael@laptop:/tmp/tmp.Yesz1KNOwJ]$ docker run --rm -v "$(pwd):/repo" casperdcl/git-fame
fatal: detected dubious ownership in repository at '/repo'
To add an exception for this directory, call:

	git config --global --add safe.directory /repo
Processing: 100%|██████████| 1/1 [00:00<00:00, 714.17file/s]
error: too many arguments given outside repository
usage: git shortlog [<options>] [<revision-range>] [[--] <path>...]
   or: git log --pretty=short | git shortlog [<options>]

    -c, --[no-]committer  group by committer rather than author
    -n, --[no-]numbered   sort output according to the number of commits per author
    -s, --[no-]summary    suppress commit descriptions, only provides commit count
    -e, --[no-]email      show the email address of each author
    -w[<w>[,<i1>[,<i2>]]] linewrap output
    --[no-]group <field>  group by field

Total
| Author   | loc   | coms   | fils   |  distribution   |
|----------|-------|--------|--------|-----------------|
```

**After:**
```bash
[nathanael@laptop:/tmp/tmp.Yesz1KNOwJ]$ docker run --rm -v "$(pwd):/repo" --user "$(id --user)" casperdcl/git-fame
Processing: 100%|██████████| 2/2 [00:00<00:00, 374.71file/s]
Total commits: 1
Total ctimes: 1
Total files: 2
Total loc: 2
| Author         |   loc |   coms |   fils |  distribution    |
|:---------------|------:|-------:|-------:|:-----------------|
| Nathanaël Houn |     2 |      1 |      2 | 100.0/ 100/100.0 |
```