### PR TITLE
Snap: Add etc/gitconfig plug

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -21,8 +21,13 @@ parts:
     override-stage: |
         craftctl default
         craftctl set version=$(bin/python3 -m gitfame --version)
+plugs:
+  etc-gitconfig:
+    interface: system-files
+    read:
+    - /etc/gitconfig
 apps:
   git-fame:
     command: bin/git-fame
     completer: completion.sh
-    plugs: [home]
+    plugs: [home, etc-gitconfig]


### PR DESCRIPTION
I noticed the following when using the snap:

```
jmercer@xt-uk-jdk5q94:~/Development$ snap install git-fame
git-fame 3.1.1 from Casper (casper-dcl) installed
jmercer@xt-uk-jdk5q94:~/Development$ git-fame 
warning: unable to access '/etc/gitconfig': Permission denied
warning: unable to access '/etc/gitconfig': Permission denied
warning: unable to access '/etc/gitconfig': Permission denied
fatal: unknown error occurred while reading the configuration files
warning: unable to access '/etc/gitconfig': Permission denied
warning: unable to access '/etc/gitconfig': Permission denied
warning: unable to access '/etc/gitconfig': Permission denied
fatal: unknown error occurred while reading the configuration files
Processing: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 183.92file/s]
warning: unable to access '/etc/gitconfig': Permission denied
warning: unable to access '/etc/gitconfig': Permission denied
warning: unable to access '/etc/gitconfig': Permission denied
fatal: unknown error occurred while reading the configuration files
Total 
| Author   | loc   | coms   | fils   |  distribution   |
|----------|-------|--------|--------|-----------------|
```

I downloaded, unpacked, and manually edited the meta/snap.yaml in the .snap file to add a plug to access /etc/gitconfig and that seems to have fixed it (after doing a `sudo snap connect git-fame:etc-gitconfig`) so I have replicated my changes in the codebase.  Hopefully this is correct, I have limited knowledge of snaps and their workings, so apologies if this is not right.