### PR TITLE
fix KeyError in auth2new when using --since/--until

### DIFF
--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -343,6 +343,12 @@ def _get_auth_stats(gitdir, branch="HEAD", since=None, include_files=None, exclu
         auth_stats = {}
 
         for auth, stats in old.items():
+            if auth not in auth2new:
+                m = auth.rfind(' <')
+                if m >= 0:
+                    auth2new[auth] = auth[m + 2:-1] if (show & SHOW_EMAIL) else auth[:m]
+                else:
+                    auth2new[auth] = auth
             i = auth_stats.setdefault(auth2new[auth], defaultdict(int, files=set(), ctimes=[]))
             i["files"].update(stats["files"])
             for k, v in stats.items():

--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -344,11 +344,8 @@ def _get_auth_stats(gitdir, branch="HEAD", since=None, include_files=None, exclu
 
         for auth, stats in old.items():
             if auth not in auth2new:
-                m = auth.rfind(' <')
-                if m >= 0:
-                    auth2new[auth] = auth[m + 2:-1] if (show & SHOW_EMAIL) else auth[:m]
-                else:
-                    auth2new[auth] = auth
+                # https://github.com/casperdcl/git-fame/issues/122
+                auth2new[auth] = re.match('(.*) <(.*)>$', auth).group(2 if (show & SHOW_EMAIL) else 1) or auth
             i = auth_stats.setdefault(auth2new[auth], defaultdict(int, files=set(), ctimes=[]))
             i["files"].update(stats["files"])
             for k, v in stats.items():


### PR DESCRIPTION
## Summary

Fix `KeyError` in `_get_auth_stats` when using `--since`/`--until` flags.

## Problem

When `--since`/`--until` is used, `git blame` may attribute surviving lines of code to authors whose commits fall outside the date range (incompletely stripped boundary commits). These authors end up in `auth_stats` but not in `auth2new` (populated from `git shortlog`), causing a `KeyError` at line 360 when remapping author keys for name-only or email-only display.

## Fix

When an author from `auth_stats` is missing from `auth2new`, derive their display name/email directly from the `"Name <email>"` auth string, keeping output formatting consistent.

Fixes #122.

> Note: this is a different root cause than #115 (which was about blank emails).