### PR TITLE
fix: count LOC/files when passing multiple repos

### DIFF
--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -269,12 +269,12 @@ def _get_auth_stats(gitdir, branch="HEAD", since=None, include_files=None, exclu
     if churn & CHURN_SLOC:
         for fname in tqdm(file_list, desc=gitdir if prefix_gitdir else "Processing", disable=silent_progress,
                           unit="file"):
-            if prefix_gitdir:
-                fname = path.join(gitdir, fname)
+            # `fname` is relative to `gitdir`, so only prefix the reported name
+            display_fname = path.join(gitdir, fname) if prefix_gitdir else fname
             try:
                 blame_out = check_output(base_cmd + [branch, fname], stderr=subprocess.STDOUT)
             except Exception as err:
-                getattr(log, "warn" if warn_binary else "debug")(fname + ':' + str(err))
+                getattr(log, "warn" if warn_binary else "debug")(display_fname + ':' + str(err))
                 continue
             log.log(logging.NOTSET, blame_out)
 
@@ -291,7 +291,7 @@ def _get_auth_stats(gitdir, branch="HEAD", since=None, include_files=None, exclu
             for loc, name, email, tstamp in RE_AUTHS_BLAME.findall(blame_out): # for each chunk
                 loc = int(loc)
                 auth = f'{name} <{email}>'
-                stats_append(fname, auth, loc, tstamp)
+                stats_append(display_fname, auth, loc, tstamp)
 
     else:
         with tqdm(total=1, desc=gitdir if prefix_gitdir else "Processing", disable=silent_progress, unit="repo") as t:

--- a/tests/test_gitfame.py
+++ b/tests/test_gitfame.py
@@ -221,3 +221,31 @@ def test_manpath():
 def test_multiple_gitdirs():
     """test multiple gitdirs"""
     main(['.', '.'])
+
+
+def test_multiple_gitdirs_loc(capsys):
+    """test surviving loc are counted for each of multiple gitdirs"""
+    import subprocess
+    from os import chdir, getcwd
+    tmp = mkdtemp()
+    cwd = getcwd()
+    try:
+        for name in ("repo_a", "repo_b"):
+            repo = path.join(tmp, name)
+            subprocess.check_call(["git", "init", "-q", repo])
+            with open(path.join(repo, name + ".txt"), 'w') as fd:
+                fd.write("one\ntwo\nthree\n")
+            commit = ["-c", "user.name=tester", "-c", "user.email=tester@example.com", "commit", "-qm", "initial"]
+            for cmd in (["add", "-A"], commit):
+                subprocess.check_call(["git", "-C", repo] + cmd)
+
+        chdir(tmp)          # relative gitdirs, as reported
+        capsys.readouterr() # clear output
+        main(['-s', "repo_a", "repo_b"])
+        out = capsys.readouterr().out
+    finally:
+        chdir(cwd)
+        rmtree(tmp, True)
+
+    assert "Total loc: 6" in out
+    assert "Total files: 2" in out


### PR DESCRIPTION
Closes #64.

With more than one gitdir, `_get_auth_stats` prefixed each filename with the gitdir *before* passing it to `git -C <gitdir> blame`, so git was asked for `<gitdir>/<gitdir>/<file>`. Every blame failed and was swallowed by the surrounding `try/except`, leaving the default `--loc=surviving` with zero loc/files/ctimes (commit counts come from `shortlog`, which is why only those survived — matching @casperdcl's note that `--loc=ins,del` works).

The prefix is only needed for the reported name, so it now goes to a separate `display_fname` used for logging and `stats_append`, while the repo-relative `fname` is passed to git. The added test runs gitfame over two relative gitdirs and fails on `main` with `KeyError: 'loc'`.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
