### PR TITLE
fix svg output truncated at the right (#126)

### DIFF
--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -201,13 +201,22 @@ def tabulate(auth_stats, stats_tot, sort='loc', bytype=False, backend='md', cost
         table = tabber.tabulate(tab, COL_NAMES, tablefmt=backend, floatfmt='.0f')
         if svg:
             rows = table.split('\n')
-            return ('<svg xmlns="http://www.w3.org/2000/svg"'
-                    f' width="{len(rows[0]) / 2 + 1}em" height="{len(rows)}em">'
+            font_size = 15
+            # typical monospace advance (`textLength` below makes it exact for any font)
+            char_width = 0.6 * font_size
+            # `em` in the root `<svg>`'s size refers to the (inherited) font size of the `<svg>`
+            # element itself rather than to `font-size` below, so use user units instead
+            svg_width = char_width * max(map(len, rows))
+            # 0.2em of padding above the first & below the last row
+            svg_height = font_size * (len(rows) + 0.7)
+            return (f'<svg xmlns="http://www.w3.org/2000/svg" width="{svg_width:g}" height="{svg_height:g}"'
+                    f' viewBox="0 0 {svg_width:g} {svg_height:g}">'
                     '<rect x="0" y="0" width="100%" height="100%"'
                     ' fill="white" fill-opacity="0.5" rx="5"/>'
-                    '<text x="0" y="-0.5em" font-size="15"'
+                    f'<text x="0" y="0.2em" font-size="{font_size}"'
                     ' font-family="monospace" style="white-space: pre">' +
-                    ''.join(f'<tspan x="0" dy="1em">{row}</tspan>' for row in rows) + '</text></svg>')
+                    ''.join(f'<tspan x="0" dy="1em" textLength="{char_width * len(row):g}"'
+                            f' lengthAdjust="spacingAndGlyphs">{row}</tspan>' for row in rows) + '</text></svg>')
         return totals + table
 
         # from ._utils import tighten

--- a/tests/test_gitfame.py
+++ b/tests/test_gitfame.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from json import loads
 from os import path
@@ -134,6 +135,29 @@ def test_tabulate_tabulate():
       Not Committed Yet        75       0       4  12.2/ 0.0/28.6"""))
     except ImportError as err:
         raise skip(str(err))
+
+
+def test_tabulate_svg():
+    """Test SVG tabulate"""
+    svg = _gitfame.tabulate(auth_stats, stats_tot, backend='svg')
+    assert svg.startswith('<svg ') and svg.endswith('</svg>')
+    rows = re.findall('<tspan[^>]*>(.*?)</tspan>', svg)
+    assert rows and len(set(map(len, rows))) == 1
+
+    size = {}
+    for i in ('width', 'height'):
+        value, unit = re.search(f'{i}="([\\d.]+)([^"]*)"', svg).groups()
+        # `em` would refer to the `<svg>`'s own font size rather than to `font-size` below
+        assert not unit, f'viewport {i}="{value}{unit}" is not in user units'
+        size[i] = float(value)
+    width, height = size['width'], size['height']
+
+    # the viewport must fit the text (rendered at `font-size` in a `0.6em`-advance monospace)
+    font_size = float(re.search('font-size="([\\d.]+)"', svg).group(1))
+    assert width >= 0.6 * font_size * len(rows[0])
+    assert height >= font_size * (len(rows) + 0.5)
+    # ... and the text must be forced to fit, whatever the font's actual metrics
+    assert [float(i) for i in re.findall('textLength="([\\d.]+)"', svg)] == [width] * len(rows)
 
 
 def test_tabulate_enum():


### PR DESCRIPTION
Fixes #126.

## Cause

The `<svg>` viewport is smaller than the text it contains, so the table is clipped:

```python
f' width="{len(rows[0]) / 2 + 1}em" height="{len(rows)}em">'
```

1. `em` in the root `<svg>`'s `width`/`height` resolves against the font size of the `<svg>` element *itself* — inherited, i.e. 16px by default — not against the `font-size="15"` set on the `<text>` below.
2. `/2` assumes a `0.5em` glyph advance; real monospace fonts advance ~`0.6em` (measured 9.03px at `font-size=15`, i.e. `0.602em`).

For this repo's own table (72-char rows) that gives a 592px viewport for 650.2px of text, so the last ~6 characters are cut off — the `distributi` in the issue.

`y="-0.5em"` is off too: it puts the first baseline at 7.5px while the ascender needs ~14px, clipping the table's top border row, and leaves ~1.3em of unused space at the bottom.

## Fix

Size the viewport in user units derived from `font_size`, add a `viewBox`, and pin each row's advance with `textLength`/`lengthAdjust="spacingAndGlyphs"`.

`textLength` makes the result independent of the renderer's actual font metrics (Consolas advances `0.55em`, DejaVu Sans Mono `0.602em`, ...), and renderers that ignore it still get a correct layout, since the viewport is sized for the usual `0.6em`.

## Verified

Measured in Chrome with `getComputedTextLength()`/`getBBox()`:

| | viewport | text ink |
|---|---|---|
| before | 592 x 240 | 650.2 wide, y from -6.5 to 221 |
| after | 648 x 235.5 | 648 wide, y from 4 to 231.5 |

The text now fits exactly, with symmetric 4px vertical padding. Forcing a different monospace font (Courier New) and even a proportional one (Times) still measures `x + width == 648` — no overflow, columns stay aligned.

`test_tabulate_svg` covers the regression: it asserts the viewport is in user units, is big enough for the text, and that every row carries a `textLength` equal to the viewport width. It fails on the current code with `viewport width="35.0em" is not in user units`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)