### PR TITLE
escape svg text (#128)

### DIFF
--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -65,6 +65,7 @@ from collections import defaultdict
 from functools import partial
 from importlib.metadata import PackageNotFoundError, version
 from os import path
+from xml.sax.saxutils import escape
 
 from ._utils import TERM_WIDTH, Str, TqdmStream, check_output, fext, int_cast_or_len, merge_stats, print_unicode, tqdm
 
@@ -207,7 +208,7 @@ def tabulate(auth_stats, stats_tot, sort='loc', bytype=False, backend='md', cost
                     ' fill="white" fill-opacity="0.5" rx="5"/>'
                     '<text x="0" y="-0.5em" font-size="15"'
                     ' font-family="monospace" style="white-space: pre">' +
-                    ''.join(f'<tspan x="0" dy="1em">{row}</tspan>' for row in rows) + '</text></svg>')
+                    ''.join(f'<tspan x="0" dy="1em">{escape(row)}</tspan>' for row in rows) + '</text></svg>')
         return totals + table
 
         # from ._utils import tighten

--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -65,7 +65,6 @@ from collections import defaultdict
 from functools import partial
 from importlib.metadata import PackageNotFoundError, version
 from os import path
-from xml.sax.saxutils import escape
 
 from ._utils import TERM_WIDTH, Str, TqdmStream, check_output, fext, int_cast_or_len, merge_stats, print_unicode, tqdm
 
@@ -201,6 +200,7 @@ def tabulate(auth_stats, stats_tot, sort='loc', bytype=False, backend='md', cost
         tab = [[i[0][:COL_LENS[0]]] + i[1:] for i in tab]
         table = tabber.tabulate(tab, COL_NAMES, tablefmt=backend, floatfmt='.0f')
         if svg:
+            from xml.sax.saxutils import escape  # nosec B406, yapf: disable
             rows = table.split('\n')
             return ('<svg xmlns="http://www.w3.org/2000/svg"'
                     f' width="{len(rows[0]) / 2 + 1}em" height="{len(rows)}em">'

--- a/tests/test_gitfame.py
+++ b/tests/test_gitfame.py
@@ -4,6 +4,7 @@ from os import path
 from shutil import rmtree
 from tempfile import mkdtemp
 from textwrap import dedent
+from xml.etree import ElementTree
 
 from pytest import mark, skip
 
@@ -134,6 +135,15 @@ def test_tabulate_tabulate():
       Not Committed Yet        75       0       4  12.2/ 0.0/28.6"""))
     except ImportError as err:
         raise skip(str(err))
+
+
+def test_tabulate_svg_escape():
+    """Test SVG tabulate escapes markup in author names"""
+    stats = {'<script/> & co': {'files': {'setup.py'}, 'loc': 1, 'ctimes': [], 'commits': 1}}
+    svg = _gitfame.tabulate(stats, {'files': 1, 'loc': 1, 'commits': 1}, backend='svg')
+    ElementTree.fromstring(svg) # must be well-formed XML
+    assert '<script' not in svg
+    assert '&lt;script/&gt; &amp; co' in svg
 
 
 def test_tabulate_enum():


### PR DESCRIPTION
Fixes #128.

`--format=svg` interpolates the table rows into the document unescaped, so an author name containing `&` or `<` makes the output invalid XML and the image fails to render at all:

```xml
<tspan x="0" dy="1em">│ A &amp; B <script> │    10 │      1 │      1 │ 100.0/ 100/100.0 │</tspan>
```

Author names come from commit metadata, so they are attacker-controlled for any repository that accepted a contribution — relevant for <https://git-fame.cdcl.ml>, which renders arbitrary public repos.

Escaping is applied after the `COL_LENS[0]` truncation, so entities can't be cut in half.

`test_tabulate_svg_escape` asserts the output parses as XML and that the markup is escaped; it fails on the current code with `ParseError: not well-formed (invalid token)`.

Independent of #127 — the two touch adjacent lines, so whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)