### PR TITLE
fix svg columns misaligned by multi-codepoint graphemes

### DIFF
--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -162,6 +162,7 @@ def tabulate(auth_stats, stats_tot, sort='loc', bytype=False, backend='md', cost
     svg = backend == 'svg'
     if svg:
         backend = 'rounded_outline'
+        VERT = '│' # `rounded_outline`'s column separator
 
     if backend in ('yaml', 'yml', 'json', 'csv', 'tsv'):
         tab = [i[:-1] + [float(pc.strip()) for pc in i[-1].split('/')] for i in tab]
@@ -210,15 +211,25 @@ def tabulate(auth_stats, stats_tot, sort='loc', bytype=False, backend='md', cost
             svg_width = char_width * max(map(len, rows))
             # 0.2em of padding above the first & below the last row
             svg_height = font_size * (len(rows) + 0.7)
+
+            def cells(row):
+                """One `<tspan>` per cell, each pinned to & stretched over its own columns."""
+                # a whole-row `textLength` would spread the misfit of any cell whose glyphs don't
+                # advance by `char_width` (e.g. the 5 codepoints of "सौगात" draw as 3 clusters)
+                # across the entire row, displacing every column separator on it
+                col = 0
+                for cell in filter(None, re.split(f'({VERT})', row)):
+                    yield (f'<tspan x="{char_width * col:g}" textLength="{char_width * len(cell):g}"'
+                           f' lengthAdjust="spacingAndGlyphs">{escape(cell)}</tspan>')
+                    col += len(cell)
+
             return (f'<svg xmlns="http://www.w3.org/2000/svg" width="{svg_width:g}" height="{svg_height:g}"'
                     f' viewBox="0 0 {svg_width:g} {svg_height:g}">'
                     '<rect x="0" y="0" width="100%" height="100%"'
                     ' fill="white" fill-opacity="0.5" rx="5"/>'
                     f'<text x="0" y="0.2em" font-size="{font_size}"'
                     ' font-family="monospace" style="white-space: pre">' +
-                    ''.join(f'<tspan x="0" dy="1em" textLength="{char_width * len(row):g}"'
-                            f' lengthAdjust="spacingAndGlyphs">{escape(row)}</tspan>'
-                            for row in rows) + '</text></svg>')
+                    ''.join(f'<tspan x="0" dy="1em">{"".join(cells(row))}</tspan>' for row in rows) + '</text></svg>')
         return totals + table
 
         # from ._utils import tighten

--- a/gitfame/_gitfame.py
+++ b/gitfame/_gitfame.py
@@ -162,7 +162,6 @@ def tabulate(auth_stats, stats_tot, sort='loc', bytype=False, backend='md', cost
     svg = backend == 'svg'
     if svg:
         backend = 'rounded_outline'
-        VERT = '│' # `rounded_outline`'s column separator
 
     if backend in ('yaml', 'yml', 'json', 'csv', 'tsv'):
         tab = [i[:-1] + [float(pc.strip()) for pc in i[-1].split('/')] for i in tab]
@@ -214,11 +213,9 @@ def tabulate(auth_stats, stats_tot, sort='loc', bytype=False, backend='md', cost
 
             def cells(row):
                 """One `<tspan>` per cell, each pinned to & stretched over its own columns."""
-                # a whole-row `textLength` would spread the misfit of any cell whose glyphs don't
-                # advance by `char_width` (e.g. the 5 codepoints of "सौगात" draw as 3 clusters)
-                # across the entire row, displacing every column separator on it
                 col = 0
-                for cell in filter(None, re.split(f'({VERT})', row)):
+                # split on 'rounded_outline' separator
+                for cell in filter(None, re.split('(\u2502)', row)):
                     yield (f'<tspan x="{char_width * col:g}" textLength="{char_width * len(cell):g}"'
                            f' lengthAdjust="spacingAndGlyphs">{escape(cell)}</tspan>')
                     col += len(cell)

--- a/tests/test_gitfame.py
+++ b/tests/test_gitfame.py
@@ -193,7 +193,7 @@ def test_tabulate_svg():
 def test_tabulate_svg_grapheme_clusters():
     """Test SVG tabulate aligns rows containing multi-codepoint graphemes"""
     # 5 codepoints drawn as 3 clusters: a whole-row `textLength` would squeeze the entire row
-    name = 'Saugat Pachhai (सौगात)'
+    name = 'सौगात'
     stats = {
         name: {'files': {'setup.py'}, 'loc': 1, 'ctimes': [], 'commits': 1},
         'ASCII': {'files': {'setup.py'}, 'loc': 1, 'ctimes': [], 'commits': 1}}
@@ -306,7 +306,9 @@ def test_multiple_gitdirs_loc(capsys):
             subprocess.check_call(["git", "init", "-q", repo])
             with open(path.join(repo, name + ".txt"), 'w') as fd:
                 fd.write("one\ntwo\nthree\n")
-            commit = ["-c", "user.name=tester", "-c", "user.email=tester@example.com", "commit", "-qm", "initial"]
+            commit = [
+                "-c", "user.name=tester", "-c", "user.email=tester@example.com", "commit", "--no-gpg-sign", "-qm",
+                "initial"]
             for cmd in (["add", "-A"], commit):
                 subprocess.check_call(["git", "-C", repo] + cmd)
 

--- a/tests/test_gitfame.py
+++ b/tests/test_gitfame.py
@@ -147,27 +147,64 @@ def test_tabulate_svg_escape():
     assert '&lt;script/&gt; &amp; co' in svg
 
 
+SVG_NS = {'': 'http://www.w3.org/2000/svg'}
+
+
+def svg_grid(svg):
+    """(viewport width, `font-size`, rows of `(column, text)` cells) of a tabulated SVG"""
+    # must be well-formed XML
+    root = ElementTree.fromstring(svg)
+    size = {}
+    for i in ('width', 'height'):
+        value, unit = re.fullmatch('([\\d.]+)(.*)', root.get(i)).groups()
+        # `em` would refer to the `<svg>`'s own font size rather than to `font-size` below
+        assert not unit, f'viewport {i}="{value}{unit}" is not in user units'
+        size[i] = float(value)
+    text = root.find('text', SVG_NS)
+    font_size = float(text.get('font-size'))
+    # a monospace advance; `textLength` makes it exact for any font
+    char_width = 0.6 * font_size
+
+    rows = []
+    for row in text.findall('tspan', SVG_NS):
+        cells, col = [], 0
+        for cell in row.findall('tspan', SVG_NS):
+            # each cell is pinned to & stretched over its own columns, so that a cell whose
+            # glyphs don't advance by `char_width` cannot displace the ones after it
+            assert float(cell.get('x')) == char_width * col
+            assert float(cell.get('textLength')) == char_width * len(cell.text)
+            cells.append((col, cell.text))
+            col += len(cell.text)
+        assert char_width * col == size['width'], 'row does not span the viewport'
+        rows.append(cells)
+    assert rows and size['height'] >= font_size * (len(rows) + 0.5)
+    return size['width'], font_size, rows
+
+
 def test_tabulate_svg():
     """Test SVG tabulate"""
     svg = _gitfame.tabulate(auth_stats, stats_tot, backend='svg')
     assert svg.startswith('<svg ') and svg.endswith('</svg>')
-    rows = re.findall('<tspan[^>]*>(.*?)</tspan>', svg)
-    assert rows and len(set(map(len, rows))) == 1
-
-    size = {}
-    for i in ('width', 'height'):
-        value, unit = re.search(f'{i}="([\\d.]+)([^"]*)"', svg).groups()
-        # `em` would refer to the `<svg>`'s own font size rather than to `font-size` below
-        assert not unit, f'viewport {i}="{value}{unit}" is not in user units'
-        size[i] = float(value)
-    width, height = size['width'], size['height']
-
+    width, font_size, rows = svg_grid(svg)
     # the viewport must fit the text (rendered at `font-size` in a `0.6em`-advance monospace)
-    font_size = float(re.search('font-size="([\\d.]+)"', svg).group(1))
-    assert width >= 0.6 * font_size * len(rows[0])
-    assert height >= font_size * (len(rows) + 0.5)
-    # ... and the text must be forced to fit, whatever the font's actual metrics
-    assert [float(i) for i in re.findall('textLength="([\\d.]+)"', svg)] == [width] * len(rows)
+    assert width >= 0.6 * font_size * len(''.join(text for _, text in rows[0]))
+
+
+def test_tabulate_svg_grapheme_clusters():
+    """Test SVG tabulate aligns rows containing multi-codepoint graphemes"""
+    # 5 codepoints drawn as 3 clusters: a whole-row `textLength` would squeeze the entire row
+    name = 'Saugat Pachhai (सौगात)'
+    stats = {
+        name: {'files': {'setup.py'}, 'loc': 1, 'ctimes': [], 'commits': 1},
+        'ASCII': {'files': {'setup.py'}, 'loc': 1, 'ctimes': [], 'commits': 1}}
+    svg = _gitfame.tabulate(stats, {'files': 1, 'loc': 2, 'commits': 2}, backend='svg')
+    # `svg_grid` asserts that every cell sits on the character grid
+    _, _, rows = svg_grid(svg)
+    # the name is drawn as one cell, so its clusters stay intact
+    assert any(text.strip() == name for row in rows for _, text in row)
+    # ... and the separators are at the same columns on every row which has them
+    seps = {tuple(col for col, text in row) for row in rows if len(row) > 1}
+    assert len(seps) == 1
 
 
 def test_tabulate_enum():


### PR DESCRIPTION
Fixes #133 (regression from #127).

A whole-row `textLength` spreads the misfit of any cell whose glyphs don't advance by `char_width` across the entire row, displacing every column separator on it. `Saugat Pachhai (सौगात)` is padded by `len()` to 5 columns but drawn as 3 grapheme clusters, so its row gets squeezed and no longer lines up with the rest of the table.

Draw one `<tspan>` per cell instead — split on `rounded_outline`'s `│`, each pinned at `x = char_width * column` with its own `textLength` — so any such misfit stays inside the cell which causes it, and the separators keep landing on exact grid positions. The row still fills the viewport exactly, so #126 stays fixed for any font.

Alternatives I measured and discarded:

- an `x` list per codepoint: aligns perfectly, but detaches the vowel signs from their consonants — it renders the name as garbage;
- an `x` per grapheme cluster: also aligns, but pins each cluster to its own column, leaving gaps *inside* the word (`सौ गा त`).

The remaining (much smaller) artefact is that the offending cell's own content is stretched over its reserved columns. Rendering it correctly would need the padding itself to be cluster-aware, which is a `tabulate` concern and affects the text backends equally — out of scope here.

`test_tabulate_svg` now checks the whole grid via a `svg_grid()` helper (every cell pinned at `char_width * column`, `textLength` matching its own text, every row spanning the viewport), and `test_tabulate_svg_grapheme_clusters` covers the case above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

